### PR TITLE
enable comments in mutline dockerfile commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -206,8 +206,15 @@ function Validator(rulefile) {
       }
       while (isPartialLine(line)) {
         line = line.replace(continuationRegex, " ");
-        line = line + linesArr[currentLine + lineOffSet];
-        linesArr[currentLine + lineOffSet] = undefined;
+        // we can comment inside commands
+        if (linesArr[currentLine + lineOffSet][0] === '#'){
+          linesArr[currentLine + lineOffSet] = undefined;
+          // very hacky and bad
+          line = line + "\\";
+        } else {
+          line = line + linesArr[currentLine + lineOffSet];
+          linesArr[currentLine + lineOffSet] = undefined;
+        }
         lineOffSet++;
       }
       // First instruction must be FROM


### PR DESCRIPTION
Hi, 

I've run into issue with dockerfile_lint, when checking Dockerfiles with following syntax:

RUN cmd1 && \
\# need comment here
        cmd2 && \
\# another comment here
        cmd3

which is completely fine in Docker. Dockerfile_lint will complaint about invalid instruction cmd2...

I've made a very "hacky" patch to workaround this issue. I hope it can be done in a better way.

David